### PR TITLE
Update QGIS and description plugins

### DIFF
--- a/source/a_releasenotes.rst
+++ b/source/a_releasenotes.rst
@@ -20,8 +20,8 @@ The following has been released:
 - Bugfix in the ThreediToolbox
 - Update land use map for the calculation of damage estimations
 
-Download the latest version of the `Modeller Interface <https://docs.3di.live/modeller-interface-downloads/3DiModellerInterface-OSGeo4W-3.16.4-1-Setup-x86_64.exe>`_ 
-. For QGIS users: upgrade the plugin using the plugin panel. In case this doesn't work, it is possible to install the plugins as zip file. The latest version is of the `ThreediToolbox 1.16 <https://plugins.lizard.net/ThreeDiToolbox.1.16.1.zip>`_  the latest version the `Threedi-API-QGIS client is 2.4.0 <https://plugins.lizard.net/threedi_api_qgis_client.2.4.0.zip>`_. 
+Download the latest version of the `Modeller Interface <https://docs.3di.live/modeller-interface-downloads/3DiModellerInterface-OSGeo4W-3.16.4-1-Setup-x86_64.exe>`_ , which at the time of writing uses QGIS 3.16.4. 
+For QGIS users: upgrade the plugin using the plugin panel. In case this doesn't work, it is possible to install the plugins as zip file. The latest version is of the `ThreediToolbox 1.16 <https://plugins.lizard.net/ThreeDiToolbox.1.16.1.zip>`_  the latest version the `Threedi-API-QGIS client is 2.4.0 <https://plugins.lizard.net/threedi_api_qgis_client.2.4.0.zip>`_. 
 
 
 Local calculation of water depth & water level maps

--- a/source/d_before_you_begin.rst
+++ b/source/d_before_you_begin.rst
@@ -5,7 +5,7 @@ Before You Begin
 
 The tutorials below are aimed at giving you some examples on how to use, modify or create your 3Di models. They show you how to create different types of models for different purposes or add elements to existing models. The first tutorials aim to give you an introduction to 3Di as well explaining some basic steps. They therefore explain the steps and reasons behind them quite extensively. The later tutorials assume you have sufficient knowledge about 3Di and modelling in general. They are less extensive and can be used as cheat sheets for performing different tasks.
 
-All tutorials assume you have some knowledge of 3Di and have access to QGIS, the 3Di QGIS plugin, Google Chrome and TortoiseHG. They also assume that your organization has uploaded one or more 3Di models for use in the 3Di portal. For a complete overview of the software required, check the software section.
+All tutorials assume you have some knowledge of 3Di and have access to QGIS, the 3Di QGIS plugin, Google Chrome and TortoiseHG. They also assume that your organisation has uploaded one or more 3Di models for use in the 3Di portal. For a complete overview of the software required, check the software section.
 
 Before you begin consider the following.
 
@@ -18,7 +18,7 @@ To use 3Di you need these software packages:
 
 * Recent version of Google Chrome (`Get Chrome <https://www.google.nl/chrome/browser/desktop/index.html>`_)
 
-* The `Modeller Interface <https://docs.3di.lizard.net/modeller-interface-downloads/3DiModellerInterface-OSGeo4W-3.4.13-1-Setup-x86_64.exe>`_ or install QGIS with the appropriate plugins. For more details on how to do this see :ref:`plugin_installation`
+* The 'Modeller Interface' or install a recent version of QGIS with the appropriate plugins. For more details on how to do this see :ref:`qgisplugin`
 
 * Recent version of TortoiseHG (`Get TortoiseHG <https://tortoisehg.bitbucket.io/download/index.html>`_)
 

--- a/source/d_qgis_plugin.rst
+++ b/source/d_qgis_plugin.rst
@@ -8,19 +8,19 @@ Introduction
 The Modeller Interface (MI) will help you with building 3Di models and analysing results locally. The MI will also assist you in interacting with the 3Di-API and downloading the results from the 3Di calculation servers. The MI is part of QGIS with various pre-installed plugins: the 3Di Toolbox to analyse results, the 3Di API Client to start calculations, download results and some third party plugins. The interface has been cleaned compared to a standard QGIS installation, it shows only relevant buttons for model building and analysing. 
 
 - Install the `Modeller Interface <https://docs.3di.live/modeller-interface-downloads/3DiModellerInterface-OSGeo4W-3.16.4-1-Setup-x86_64.exe>`_  or
-- Install QGIS, and install the 3Di toolbox as a QGIS plugin
+- Install the LTR of QGIS, and install the 3Di toolbox as a QGIS plugin
 
-Older versions of the Modeller Interface are found in the `archive <https://docs.3di.live/modeller-interface-downloads>`_. 
 
-For more information on installing the plugin see `3Di Toolbox plug-in <https://github.com/nens/threedi-qgis-plugin/wiki>`_. For more information on viewing and editing 3Di models in QGIS see :ref:`adjust_model`. 
-The section below explains the use of various options of the modeller interface. More subjects will be added regularly.
+.. note::
+    Are you running into problems when downloading or updating the software? 
+    Please contact our support office (servicedesk@nelen-schuurmans.nl)
 
 .. _plugin_installation:
 
 Plugin Installation 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* QGIS 3.10 64bit Long term release(`Get QGIS <http://www.qgis.org/en/site/forusers/download.html#>`_ use the standalone installers)
+* QGIS 3.16 64bit Long term release (`Get QGIS <http://www.qgis.org/en/site/forusers/download.html#>`_ and use the standalone installer)
 
     After the installation of QGIS, set the interface language and locale to American English. This makes it easier to understand the instructions in this documentation. Some locales do not support scientific notations of numbers, these are required for very small numbers (e.g. 1e-09).
 
@@ -30,15 +30,18 @@ Plugin Installation
     * For Locale, choose 'English UnitedStates (en_US)'
     * Restart QGIS
 
-* QGiS 3Di plug-in specially designed for 3Di (`Get 3Di plug-in <https://github.com/nens/threedi-qgis-plugin/wiki>`_)
+* QGiS 3Di plug-in specially designed for 3Di
+	
+	* 3Di Toolbox
+	* 3Di API client
 
-The 3Di Toolbox works for:
 
-- QGIS 3.10.x (LTR after february 2020)
+The plugins work for:
+
+- QGIS 3.16.x (LTR after March 2021)
 - 64-bit version of QGIS (see below for more details)
 - 3Di v2 results
 
-For a more extended description of installing QGIS, the 3Di-Toolbox and troubleshooting go to: https://github.com/nens/ThreeDiToolbox/wiki/Installation
 
 To install the 3Di-Toolbox plugin follow the steps below: 
 
@@ -59,6 +62,8 @@ To install the 3Di-Toolbox plugin follow the steps below:
     :alt: Install 3Di Toolbox
 
 .. _plugin_overview:
+
+To install the 3Di API client plugin follow the steps below: 
 
 7) To install the 3Di API client follow steps 1-4 above. Now you choose 3Di API client. 
 8) To active the panel of the API client, choose plugins --> 3Di API client --> 3Di API client. Now the panel will be available.


### PR DESCRIPTION
New QGIS version
remove hardcoded version from 'before you begin' and refer to 'qgis_plugin'
remove old descriptions and links that are confusing.