### PR TITLE
Revert "pin docker image version"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM sphinxdoc/sphinx-latexpdf:8.0.2
-# Pin the docker tag to use Python 3.12 to work
-# around PyPi sub-dependencies with no 3.13 wheels
+FROM sphinxdoc/sphinx-latexpdf
 
 # ARG DEBIAN_FRONTEND=noninteractive
 # RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This reverts commit d2a8ffff0d80271fc56c83862ff0652cdaf1efe8. `cmarkgfm` has released a new version which supports Python 3.13.